### PR TITLE
Correct the nginx X-Forwarded-Proto lines so that rails request.protocol is right

### DIFF
--- a/cookbooks/omnibus-supermarket/templates/default/rails.nginx.conf.erb
+++ b/cookbooks/omnibus-supermarket/templates/default/rails.nginx.conf.erb
@@ -20,7 +20,7 @@ server {
   proxy_set_header        Host            $host;
   proxy_set_header        X-Real-IP       $remote_addr;
   proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-  proxy_set_header        X-Forwarded-Proto https;
+  proxy_set_header        X-Forwarded-Proto http;
   proxy_pass_request_headers on;
   proxy_connect_timeout   90;
   proxy_send_timeout      90;
@@ -119,7 +119,7 @@ server {
     proxy_set_header HOST $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $remote_addr;
-    proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+    proxy_set_header X-Forwarded-Proto https;
     proxy_pass http://rails;
     proxy_redirect off;
 


### PR DESCRIPTION
The way nginx is configured, it sends the incorrect `X-Forwarded-Proto` header to rails.   This affected the /universe endpoint and breaks all cookbook downloads via Berkshelf.

This fixes opscode/supermarket#967